### PR TITLE
Pre-trained Word Vectors for Thai language

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ Thai National Corpus 2 | | 32M words. | Query text by genre, domain | Copyright 
 ## Pre-trained Word Vectors
 Pre-trained Model | Description | Size | Dimensions | License | Link
 --- | --- | --- | --- | --- | ---
-fastText | Skip-Gram model trained on Wikipedia using fastText | | 300 | CC BY-SA 3.0 | [Facebook]() [Bin & Text](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.zip) + [Text Only](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.vec) 
+fastText | Skip-Gram model trained on Wikipedia using fastText | | 300 | CC BY-SA 3.0 | [Facebook](https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md) + [Bin & Text](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.zip) + [Text Only](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.vec) 

--- a/README.md
+++ b/README.md
@@ -110,4 +110,5 @@ Thai National Corpus 2 | | 32M words. | Query text by genre, domain | Copyright 
 
 ## Pre-trained Word Vectors
 Pre-trained Model | Description | Size | Dimensions | License | Link
+--- | --- | --- | --- | --- | ---
 fastText | Skip-Gram model trained on Wikipedia using fastText | | 300 | CC BY-SA 3.0 | [Facebook]() [Bin+Text](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.zip) + [Text Only](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.vec) 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,6 @@ Library | Description | Size | Features | License | Link
 --- | --- | --- | --- | --- | ---
 Thai National Corpus 2 | | 32M words. | Query text by genre, domain | Copyright | [CHULA](http://www.arts.chula.ac.th/~ling/TNCII/)
 
-
-
-
+## Pre-trained Word Vectors
+Pre-trained Model | Description | Size | Dimensions | License | Link
+fastText | Skip-Gram model trained on Wikipedia using fastText | | 300 | CC BY-SA 3.0 | [Facebook]() [Bin+Text](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.zip) + [Text Only](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.vec) 

--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ Thai National Corpus 2 | | 32M words. | Query text by genre, domain | Copyright 
 ## Pre-trained Word Vectors
 Pre-trained Model | Description | Size | Dimensions | License | Link
 --- | --- | --- | --- | --- | ---
-fastText | Skip-Gram model trained on Wikipedia using fastText | | 300 | CC BY-SA 3.0 | [Facebook]() [Bin+Text](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.zip) + [Text Only](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.vec) 
+fastText | Skip-Gram model trained on Wikipedia using fastText | | 300 | CC BY-SA 3.0 | [Facebook]() [Bin & Text](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.zip) + [Text Only](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.th.vec) 


### PR DESCRIPTION
Facebook trained them on Thai Wikipedia, I suspect that they used IBM's ICU as the tokenizer.